### PR TITLE
`URL` overload for `Retrofit.Builder#baseUrl`

### DIFF
--- a/retrofit/src/main/java/retrofit2/Retrofit.java
+++ b/retrofit/src/main/java/retrofit2/Retrofit.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Proxy;
 import java.lang.reflect.Type;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -447,6 +448,16 @@ public final class Retrofit {
     public Builder callFactory(okhttp3.Call.Factory factory) {
       this.callFactory = checkNotNull(factory, "factory == null");
       return this;
+    }
+
+    /**
+     * Set the API base URL.
+     *
+     * @see #baseUrl(HttpUrl)
+     */
+    public Builder baseUrl(URL baseUrl) {
+      checkNotNull(baseUrl, "baseUrl == null");
+      return baseUrl(HttpUrl.get(baseUrl.toString()));
     }
 
     /**

--- a/retrofit/src/test/java/retrofit2/RetrofitTest.java
+++ b/retrofit/src/test/java/retrofit2/RetrofitTest.java
@@ -20,6 +20,8 @@ import java.lang.annotation.Annotation;
 import java.lang.annotation.Retention;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -747,6 +749,14 @@ public final class RetrofitTest {
         .baseUrl(url)
         .build();
     assertThat(retrofit.baseUrl()).isSameAs(url);
+  }
+
+  @Test public void baseJavaUrlPropagated() throws MalformedURLException {
+    URL url = new URL("http://example.com/");
+    Retrofit retrofit = new Retrofit.Builder()
+        .baseUrl(url)
+        .build();
+    assertThat(retrofit.baseUrl()).isEqualTo(HttpUrl.get("http://example.com/"));
   }
 
   @Test public void clientNullThrows() {


### PR DESCRIPTION
Functionally does nothing, just somewhat cleaner to be able to do `baseUrl(URL)` than `baseUrl(URL#toString());` if handling a `URL` rather than `String`.
Used `HttpUrl.get(String)` as `HttpUrl.get(URL)` returns null instead of throwing an exception.